### PR TITLE
CH2570: mPDF unable to process certain parameters, leading to errors.

### DIFF
--- a/src/Mpdf.php
+++ b/src/Mpdf.php
@@ -18410,14 +18410,23 @@ class Mpdf implements \Psr\Log\LoggerAwareInterface
 					break;
 
 				case 'FONT-WEIGHT': // normal bold // Does not support: bolder, lighter, 100..900(step value=100)
-					switch (strtoupper($v)) {
-						case 'BOLD':
-							$this->SetStyle('B', true);
-							break;
-						case 'NORMAL':
-							$this->SetStyle('B', false);
-							break;
-					}
+                    switch (strtoupper($v)) {
+                        case 100:
+                        case 200:
+                        case 300:
+                        case 400:
+                        case 'NORMAL':
+                            $this->SetStyle('B', false);
+                            break;
+                        case 500:
+                        case 600:
+                        case 700:
+                        case 800:
+                        case 900:
+                        case 'BOLD':
+                            $this->SetStyle('B', true);
+                            break;
+                    }
 					break;
 
 				case 'FONT-KERNING':

--- a/src/SizeConverter.php
+++ b/src/SizeConverter.php
@@ -50,10 +50,10 @@ class SizeConverter implements \Psr\Log\LoggerAwareInterface
 	public function convert($size = 5, $maxsize = 0, $fontsize = false, $usefontsize = true)
 	{
 		$size = trim(strtolower($size));
-		// Match to:
+        // Match to:
         // - 99px
-        // - calc(9%)
-        // - calc(100% - 1px) catches first value(100%) and ignore things after it
+        // - calc(9%) catches 9%
+        // - calc(100% - 1px) catches first value(100%) and ignore things after it.
         $res = preg_match('/(?(?<=\()|^)(?P<size>[-0-9.,]+)?(?<=[-0-9.,])(?P<unit>[%a-z-]+)?/', $size, $parts);
 		if (!$res) {
 			// ignore definition

--- a/src/SizeConverter.php
+++ b/src/SizeConverter.php
@@ -50,7 +50,11 @@ class SizeConverter implements \Psr\Log\LoggerAwareInterface
 	public function convert($size = 5, $maxsize = 0, $fontsize = false, $usefontsize = true)
 	{
 		$size = trim(strtolower($size));
-		$res = preg_match('/^(?P<size>[-0-9.,]+)?(?P<unit>[%a-z-]+)?$/', $size, $parts);
+		// Match to:
+        // - 99px
+        // - calc(9%)
+        // - calc(100% - 1px) catches first value(100%) and ignore things after it
+        $res = preg_match('/(?(?<=\()|^)(?P<size>[-0-9.,]+)?(?<=[-0-9.,])(?P<unit>[%a-z-]+)?/', $size, $parts);
 		if (!$res) {
 			// ignore definition
 			$this->logger->warning(sprintf('Invalid size representation "%s"', $size), ['context' => LogContext::CSS_SIZE_CONVERSION]);


### PR DESCRIPTION
Catch values from styles like `calc(...)`. Add fake numeric font-weight support.

https://app.clubhouse.io/deskpro/story/2570/mpdf-unable-to-process-certain-parameters-leading-to-errors